### PR TITLE
Added Result.is_safe as the opposite of Result.is_error

### DIFF
--- a/src/safe_result/__init__.py
+++ b/src/safe_result/__init__.py
@@ -27,6 +27,10 @@ class Result(Generic[T, E]):
         """Check if this Result contains an error."""
         return self.error is not None
 
+    def is_safe(self) -> bool:
+        """Check if this Result does not contain an error."""
+        return self.error is None
+        
     def unwrap(self) -> T:
         """Return the value or raise the error."""
         if self.error:


### PR DESCRIPTION
Instead of writing `not result.is_error()`, you can now write `result.is_safe()`